### PR TITLE
fix: docker readonly fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic-20200219 as tmp
 ARG PLUGIN_NAME=mongodb
 ARG PLAN_TYPE=FREE
-ARG CORE_VERSION=9.2.2
+ARG CORE_VERSION=9.2.3
 ARG PLUGIN_VERSION=1.28.0
 RUN apt-get update && apt-get install -y curl zip
 RUN OS= && dpkgArch="$(dpkg --print-architecture)" && \
@@ -36,5 +36,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 RUN echo "$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')" >> /CONFIG_HASH
 RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 EXPOSE 3567
+USER "supertokens"
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["supertokens", "start"]

--- a/README.md
+++ b/README.md
@@ -77,3 +77,24 @@ docker run \
 ## Database setup
 - You do not need to ensure that the MongoDB database has started before this container is started. During bootup, SuperTokens will wait for ~1 hour for a MongoDB instance to be available.
 - If ```MONGODB_CONNECTION_URI``` is not provided, then SuperTokens will use an in memory database.
+
+## Read-only root fs
+- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
+- You will have to create a mount for `/lib/supertokens/temp/`
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-mongodb --read-only
+```
+
+```bash
+docker run \
+	-p 3567:3567 \
+	--tmpfs=/lib/supertokens/temp/:exec \
+	--read-only \
+	-d registry.supertokens.io/supertokens/supertokens-mongodb --read-only
+```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run \
 - If ```MONGODB_CONNECTION_URI``` is not provided, then SuperTokens will use an in memory database.
 
 ## Read-only root fs
-- If you wish to run this container with a read-only root filesystem, you should use the `--read-only` flag *for the container too*.
+- If you wish to run this container with a read-only root filesystem, you can do so.
 - The container still needs a temp area, where it can write its stuff, and also needs to be able to execute from there.
 - You will have to create a mount for `/lib/supertokens/temp/`
 
@@ -88,7 +88,7 @@ docker run \
 	-p 3567:3567 \
 	--mount source=/path/on/host/machine,destination=/lib/supertokens/temp/,type=bind \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-mongodb --read-only
+	-d registry.supertokens.io/supertokens/supertokens-mongodb
 ```
 
 ```bash
@@ -96,5 +96,5 @@ docker run \
 	-p 3567:3567 \
 	--tmpfs=/lib/supertokens/temp/:exec \
 	--read-only \
-	-d registry.supertokens.io/supertokens/supertokens-mongodb --read-only
+	-d registry.supertokens.io/supertokens/supertokens-mongodb
 ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,12 +31,36 @@ if [ "${1}" = 'dev' -o "${1}" = "production" -o "${1:0:2}" = "--" ]; then
     fi
 fi
 
+# if command starts with an option, prepend supertokens start
+if [ "${1}" = 'dev' -o "${1}" = "production" -o "${1:0:2}" = "--" ]; then
+    # set -- supertokens start "$@"
+    set -- supertokens start "$@"
+    # check if --foreground option is passed or not
+    if [[ "$*" != *--foreground* ]]
+    then
+        set -- "$@" --foreground
+    fi
+fi
+
 CONFIG_FILE=/usr/lib/supertokens/config.yaml
+TEMP_LOCATION_WHEN_READONLY=/lib/supertokens/temp/
 CONFIG_MD5SUM="$(md5sum /usr/lib/supertokens/config.yaml | awk '{ print $1 }')"
 
-# if files have been shared using shared volumes, make sure the ownership of the
-# /usr/lib/supertokens files still remains with supertokens user
-chown -R supertokens:supertokens /usr/lib/supertokens/
+#if it contains the readonly param, make that temp dir a temp dir for java io too
+if [[ "$*" == *--read-only* ]]
+then
+  #required by JNA
+  export _JAVA_OPTIONS=-Djava.io.tmpdir=$TEMP_LOCATION_WHEN_READONLY
+
+  #changing where the config file is written
+  ORIGINAL_CONFIG=$CONFIG_FILE
+  CONFIG_FILE="${TEMP_LOCATION_WHEN_READONLY}/config.yaml"
+  cat $ORIGINAL_CONFIG >> $CONFIG_FILE
+
+  #make sure the CLI knows which config file to pass to the core
+  set -- "$@" --with-config="$CONFIG_FILE" --with-temp-dir="$TEMP_LOCATION_WHEN_READONLY" --foreground
+fi
+
 
 if [ "$CONFIG_HASH" = "$CONFIG_MD5SUM" ]
 then
@@ -129,9 +153,6 @@ then
         then
             touch $INFO_LOG_PATH
         fi
-        # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $INFO_LOG_PATH
-        chmod +w $INFO_LOG_PATH
         echo "info_log_path: $INFO_LOG_PATH" >> $CONFIG_FILE
     else
         echo "info_log_path: null" >> $CONFIG_FILE
@@ -144,9 +165,6 @@ then
         then
             touch $ERROR_LOG_PATH
         fi
-        # make sure supertokens user has write permission on the file
-        chown supertokens:supertokens $ERROR_LOG_PATH
-        chmod +w $ERROR_LOG_PATH
         echo "error_log_path: $ERROR_LOG_PATH" >> $CONFIG_FILE
     else
         echo "error_log_path: null" >> $CONFIG_FILE
@@ -207,7 +225,7 @@ fi
 # check if no options has been passed to docker run
 if [[ "$@" == "supertokens start" ]]
 then
-    set -- "$@" --foreground
+    set -- "$@" --with-config="$CONFIG_FILE" --foreground
 fi
 
 # If container is started as root user, restart as dedicated supertokens user

--- a/test.sh
+++ b/test.sh
@@ -167,7 +167,7 @@ git checkout $PWD/config.yaml
 
 #---------------------------------------------------
 # test --read-only
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
 
 sleep 17s
 
@@ -177,15 +177,11 @@ test_hello "test --read-only"
 
 test_session_post "test --read-only"
 
-test_signup_post "test --read-only"
-
-test_signin_post "test --read-only"
-
 docker rm supertokens -f
 
 #---------------------------------------------------
 # test --read-only ARGON2
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
 
 sleep 17s
 
@@ -194,10 +190,6 @@ test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "
 test_hello "test --read-only ARGON2"
 
 test_session_post "test --read-only ARGON2"
-
-test_signup_post "test --read-only ARGON2"
-
-test_signin_post "test --read-only ARGON2"
 
 docker rm supertokens -f
 

--- a/test.sh
+++ b/test.sh
@@ -167,7 +167,7 @@ git checkout $PWD/config.yaml
 
 #---------------------------------------------------
 # test --read-only
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db
 
 sleep 17s
 
@@ -181,7 +181,7 @@ docker rm supertokens -f
 
 #---------------------------------------------------
 # test --read-only ARGON2
-docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db
 
 sleep 17s
 

--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,32 @@ test_session_post () {
     fi
 }
 
+test_signup_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signup -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signup_post in $message\n"
+        exit 1
+    fi
+}
+
+test_signin_post () {
+    message=$1
+    STATUS_CODE=$(curl -X POST http://127.0.0.1:3567/recipe/signin -H "Content-Type: application/json" -d '{
+        "email": "testing@testing.test",
+        "password": "testpassword"
+    }' -o /dev/null -w '%{http_code}\n' -s)
+    if [[ $STATUS_CODE -ne "200" ]]
+    then
+        printf "\x1b[1;31merror\xd1b[0m from test_signin_post in $message\n"
+        exit 1
+    fi
+}
+
 no_of_containers_running_at_start=`no_of_running_containers`
 
 # start mongodb server
@@ -138,6 +164,42 @@ docker rm supertokens -f
 rm -rf $PWD/info.log
 rm -rf $PWD/error.log
 git checkout $PWD/config.yaml
+
+#---------------------------------------------------
+# test --read-only
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only"
+
+test_hello "test --read-only"
+
+test_session_post "test --read-only"
+
+test_signup_post "test --read-only"
+
+test_signin_post "test --read-only"
+
+docker rm supertokens -f
+
+#---------------------------------------------------
+# test --read-only ARGON2
+docker run  --read-only -e DISABLE_TELEMETRY=true $NETWORK_OPTIONS_CONNECTION_URI -e PASSWORD_HASHING_ALG=ARGON2  --tmpfs=/lib/supertokens/temp/:exec --rm -d --name supertokens supertokens-mongodb:circleci --no-in-mem-db --read-only
+
+sleep 17s
+
+test_equal `no_of_running_containers` $((no_of_containers_running_at_start+2)) "test --read-only ARGON2"
+
+test_hello "test --read-only ARGON2"
+
+test_session_post "test --read-only ARGON2"
+
+test_signup_post "test --read-only ARGON2"
+
+test_signin_post "test --read-only ARGON2"
+
+docker rm supertokens -f
 
 docker rm mongodb -f
 


### PR DESCRIPTION
- Adds support for readonly root filesystem. (--read-only), but for that requires at least a --tmpfs for /lib/supertokens/temp
- Changes the user in the container from root to supertokens
- Removes operations from entrypoint which would require root user.